### PR TITLE
(new): Add NLP task for different embeddings

### DIFF
--- a/examples/NLP_classification_embeddings/.gitignore
+++ b/examples/NLP_classification_embeddings/.gitignore
@@ -1,0 +1,3 @@
+huggingface
+model_checkpoints
+credentials.json

--- a/examples/NLP_classification_embeddings/README.md
+++ b/examples/NLP_classification_embeddings/README.md
@@ -1,0 +1,73 @@
+# Topic Classification on Reuters-21578 News Dataset
+
+This example is intended to show you how to build the `train`, `test` and `infer` processes for the `AlectioSDK` for topic
+classification problems. We will use the [Reuters](https://martin-thoma.com/nlp-reuters/) dataset. We focus on the 20 most popular news topics. An example sentence is
+
+
+
+| label | topic |
+| ----- | ----- |
+| interest   | FED EXPECTED TO ADD RESERVES The Federal Reserve is expected to enter the U.S. government securities market to add reserves during its usual intervention period today, economists said. With federal funds trading at a steady 6-3/16 pct, most economists expect an indirect injection of temporary reserves via a medium-sized round of customer repurchase agreements. However, some economists said the Fed may arrange more aggressive system repurchase agreements. Economists would also not rule out an outright bill pass early this afternoon. Such action had been widely anticipated yesterday but failed to materialize.
+
+
+
+
+### 1. Set up a virtual environment and install Alectio SDK
+Before getting started, please make sure you completed the [initial installation instructions](../../README.md) to set-up your environment. 
+
+To recap, the steps were setting up a virtual environment and then installing the AlectioSDK in that environment. 
+
+To install the AlectioSDK from within the current directory (`./examples/NLP_classification_embeddings`) run:
+
+```
+pip install ../../.
+```
+### 2. Get Code, Data and Dependencies 
+
+First, point your terminal to the directory of this Readme file. Your terminal should look like this:
+```bash 
+(env)$~/AlectioSDK/examples/NLP_classification_embeddings
+```
+Then, clone the `Huggingface` branch of the topic classification repo. 
+```shell
+git clone --depth 1 git@gitlab.com:AntonMu/huggingface.git
+```
+If succesfull, you should have a folder within your SDK repo called `huggingface`. It should look like this:
+
+```
+├── examples
+│   ├── NLP_classification_embeddings
+│   │   └── huggingface
+│   ├── image_classification
+│   ├── object_detection
+│   └── topic_classification
+```
+
+Then install huggingface with
+
+```
+pip install huggingface/.
+
+```
+and then the remaining requirements via:
+```
+pip install -r huggingface/examples/requirements.txt
+```
+
+### 4. Build Model
+We use the BERT topic classification model that is already implemented in the reuters-hedwig repo. 
+
+### 5. Build Train, Test and Infer Processes
+To use the Alectio framework we wrap the model functions of the BERT model in [`processes.py`](./processes.py).  
+
+We can test run the processes file with:
+```python
+python processes.py
+```
+
+### 6. Build Flask App 
+Finally, to run the flask app, execute:
+
+```
+python main.py
+```

--- a/examples/NLP_classification_embeddings/config.yaml
+++ b/examples/NLP_classification_embeddings/config.yaml
@@ -1,0 +1,26 @@
+sample_payload: 'sample_payload.json'
+EXPT_DIR : "log"
+DATA_DIR : "data"
+WEIGHTS_DIR : "weights"
+exp_name: "reuters-text-classification"
+
+### TRAIN FUNCTION ARGS ###
+trainsize: 4659
+model: "roberta-base" 
+# Choose from 
+# albert-base-v2
+# albert-large-v2
+# distilbert-base-cased
+# xlm-roberta-base
+# roberta-base
+# bert-base-cased
+# bert-base-uncased
+# xlnet-base-cased
+# for more choices visit: https://huggingface.co/models
+dataset: "Reuters"
+learning_rate: 0.00002
+warmup_steps: 200
+max_steps: 600
+logging_steps: 1000
+max_seq_length: 256
+seed: -1 # If -1, we make it random

--- a/examples/NLP_classification_embeddings/labels.json
+++ b/examples/NLP_classification_embeddings/labels.json
@@ -1,0 +1,22 @@
+{
+    "0": "earn",
+    "1": "acq",
+    "2": "crude",
+    "3": "trade",
+    "4": "money-fx",
+    "5": "interest",
+    "6": "money-supply",
+    "7": "ship",
+    "8": "sugar",
+    "9": "coffee",
+    "10": "gold",
+    "11": "gnp",
+    "12": "cpi",
+    "13": "cocoa",
+    "14": "grain",
+    "15": "alum",
+    "16": "jobs",
+    "17": "reserves",
+    "18": "ipi",
+    "19": "copper"
+}

--- a/examples/NLP_classification_embeddings/main.py
+++ b/examples/NLP_classification_embeddings/main.py
@@ -1,0 +1,49 @@
+import argparse
+import yaml, json
+import os
+from alectio_sdk.flask_wrapper import Pipeline
+from processes import train, test, infer, getdatasetstate
+import logging
+
+cwd = os.path.dirname(os.path.abspath(__file__))
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--config",
+    default=os.path.join(cwd, "config.yaml"),
+    type=str,
+    help="Path to config.yaml",
+)
+
+parser.add_argument(
+    "--api_config",
+    default=os.path.join(cwd, "credentials.json"),
+    type=str,
+    help="Path to credentials.json",
+)
+
+args = parser.parse_args()
+
+with open(args.api_config, "r") as stream:
+    api_key = json.load(stream)["token"]
+    logging.info("Setting Alectio API key.")
+    os.environ["ALECTIO_API_KEY"] = api_key
+
+with open(args.config, "r") as stream:
+    args = yaml.safe_load(stream)
+
+
+# put the train/test/infer processes into the constructor
+app = Pipeline(
+    name=args["exp_name"],
+    train_fn=train,
+    test_fn=test,
+    infer_fn=infer,
+    getstate_fn=getdatasetstate,
+    args=args,
+)
+
+if __name__ == "__main__":
+    # payload = json.load(open(args["sample_payload"], "r"))
+    # app._one_loop(args=args, payload=payload)
+    app(debug=True)

--- a/examples/NLP_classification_embeddings/processes.py
+++ b/examples/NLP_classification_embeddings/processes.py
@@ -1,0 +1,208 @@
+import os
+import torch
+import sys
+import yaml
+import torch
+import argparse
+import time
+import pickle
+import subprocess
+
+# Get all the paths
+def make_call_string(arglist):
+    result_string = ""
+    for arg in arglist:
+        result_string += "".join(["--", arg[0], " ", str(arg[1]), " "])
+    return result_string
+
+
+def multi_gpu(n):
+    gpu_num = torch.cuda.device_count()
+    if gpu_num > 1:
+        n = round(n / 1.414)
+    return n
+
+
+cwd = os.path.dirname(os.path.abspath(__file__))
+
+huggingface_dir = os.path.join(cwd, "huggingface")
+
+classification_dir = os.path.join(huggingface_dir, "examples", "text-classification")
+
+data_dir = os.path.join(huggingface_dir, "glue_data", "Reuters")
+
+gpu_num = torch.cuda.device_count()
+
+batch_size_dict = {
+    "albert-base-v2": 32,
+    "albert-large-v2": 8,
+    "distilbert-base-cased": 32,
+    "xlm-roberta-base": 16,
+    "roberta-base": 32,
+    "bert-base-cased": 32,
+    "xlnet-base-cased": 16,
+    "bert-base-uncased": 32,
+}
+
+
+def getdatasetstate(config_args={}):  # Why is args empty here?
+    return {k: k for k in range(config_args["trainsize"])}
+
+
+def train(config_args, labeled, resume_from: int = 0, ckpt_file: str = ""):
+
+    # Add the args from the config file
+    model = config_args.get("model")
+    per_device_train_batch_size = batch_size_dict[model]
+    output_dir = os.path.join(cwd, config_args["EXPT_DIR"])
+
+    if not os.path.isdir(output_dir):
+        os.mkdir(output_dir)
+
+    labeled_file = os.path.join(output_dir, "indices.pkl")
+
+    with open(labeled_file, "wb") as pkl_file:
+        pickle.dump(labeled, pkl_file)
+
+    max_seq_length = multi_gpu(config_args["max_seq_length"])
+    logging_steps = multi_gpu(config_args["logging_steps"])
+    warmup_steps = multi_gpu(config_args["warmup_steps"])
+    max_steps = multi_gpu(config_args["max_steps"])
+
+    learning_rate = config_args["learning_rate"]
+    train_size = config_args["trainsize"]
+
+    seed_val = config_args["seed"]
+    if seed_val == -1:
+        seed_val = int(time.time() * 1) % 100000
+
+    arglist = [
+        ["task_name", "Reuters"],
+        ["do_train", ""],
+        ["data_dir", data_dir],
+        ["model_name_or_path", model],
+        ["per_device_train_batch_size", per_device_train_batch_size],
+        ["max_seq_length", max_seq_length],
+        ["learning_rate", learning_rate],
+        ["logging_steps", logging_steps],
+        ["output_dir", output_dir],
+        ["overwrite_output_dir", ""],
+        ["warmup_steps", warmup_steps],
+        ["max_steps", max_steps],
+        ["labeled_file", labeled_file],
+        ["train_size", train_size],
+        ["seed", seed_val],
+    ]
+
+    call_string = " ".join(
+        [
+            f"python {os.path.join(classification_dir, 'run_glue.py')}",
+            make_call_string(arglist),
+        ]
+    )
+
+    subprocess.call(call_string, shell=True)
+
+    return
+
+
+def test(config_args, ckpt_file):
+
+    output_dir = os.path.join(cwd, config_args["EXPT_DIR"])
+
+    if not os.path.isdir(output_dir):
+        os.mkdir(output_dir)
+
+    task_name = config_args["dataset"]
+    train_size = config_args["trainsize"]
+
+    arglist = [
+        ["task_name", task_name],
+        ["do_test", ""],
+        ["data_dir", data_dir],
+        ["model_name_or_path", output_dir],
+        ["output_dir", output_dir],
+        ["train_size", train_size],
+    ]
+
+    call_string = " ".join(
+        [
+            f"python {os.path.join(classification_dir, 'run_glue.py')}",
+            make_call_string(arglist),
+        ]
+    )
+
+    pred_output_test_file = os.path.join(
+        output_dir, f"test_pred_results_{task_name.lower()}.pkl",
+    )
+
+    subprocess.call(call_string, shell=True)
+
+    with open(pred_output_test_file, "rb") as pkl_file:
+        return pickle.load(pkl_file)
+
+
+def infer(config_args, unlabeled, ckpt_file):
+
+    output_dir = os.path.join(cwd, config_args["EXPT_DIR"])
+
+    if not os.path.isdir(output_dir):
+        os.mkdir(output_dir)
+
+    task_name = config_args["dataset"]
+    train_size = config_args["trainsize"]
+
+    arglist = [
+        ["task_name", task_name],
+        ["do_predict", ""],
+        ["data_dir", data_dir],
+        ["model_name_or_path", output_dir],
+        ["output_dir", output_dir],
+        ["train_size", train_size],
+    ]
+
+    call_string = " ".join(
+        [
+            f"python {os.path.join(classification_dir, 'run_glue.py')}",
+            make_call_string(arglist),
+        ]
+    )
+
+    output_test_file = os.path.join(
+        output_dir, f"raw_test_results_{task_name.lower()}.pkl",
+    )
+
+    subprocess.call(call_string, shell=True)
+
+    with open(output_test_file, "rb") as pkl_file:
+        d = pickle.load(pkl_file)
+
+    outputs = {}
+    for l in unlabeled:
+        outputs[l] = {"pre_softmax": d[l]}
+
+    return {"outputs": outputs}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.path.join(cwd, "config.yaml"),
+        type=str,
+        help="Path to config.yaml",
+    )
+    args = parser.parse_args()
+
+    with open(args.config, "r") as stream:
+        args = yaml.safe_load(stream)
+    labeled = list(range(100))
+    resume_from = None
+    ckpt_file = "ckpt_0.pt"
+
+    print("Running Training")
+    train(args, labeled=labeled, resume_from=resume_from, ckpt_file=ckpt_file)
+    print("Running Testing")
+    print(test(args, ckpt_file=ckpt_file))
+    print("Running Inference")
+    print(infer(args, unlabeled=[10, 20, 30], ckpt_file=ckpt_file))

--- a/examples/NLP_classification_embeddings/sample_payload.json
+++ b/examples/NLP_classification_embeddings/sample_payload.json
@@ -1,0 +1,8 @@
+{
+    "project_id": "d7a083a0b19811eaa7951a531e9bb4ae",
+    "experiment_id": "3334b1d0b1a011eab41f1a531e9bb4ae",
+    "cur_loop": 0,
+    "user_id": "82b4fb909f1f11ea9d300242ac110002",
+    "type": "Text Classification",
+    "bucket_name": "alectio-demo"
+}


### PR DESCRIPTION
Train NLP models with different embedding models. Possible choices are:

- albert-base-v2
- albert-large-v2
- distilbert-base-cased
- xlm-roberta-base
- roberta-base
- bert-base-cased
- bert-base-uncased
- xlnet-base-cased

But any other classification model from https://huggingface.co/models can also be used

Set your preferred embedding in the `config.yaml` file