### PR TITLE
Added estimated compute time & num_queried_per_class

### DIFF
--- a/alectio_sdk/flask_wrapper/pipeline.py
+++ b/alectio_sdk/flask_wrapper/pipeline.py
@@ -131,7 +131,7 @@ class Pipeline(object):
 
         loops_completed = self.cur_loop + 1
         time_left = convert(last_time * (self.n_loop - loops_completed))
-        print("Estimated time left for the experiment: {}".format(time_left))
+        self.app.logger.info("Estimated time left for the experiment: {}".format(time_left))
         return time_left
 
     def one_loop(self):

--- a/examples/image_classification/cifar10/config.yaml
+++ b/examples/image_classification/cifar10/config.yaml
@@ -5,5 +5,5 @@ WEIGHTS_DIR : "./weights"
 exp_name: "cifar-10"
 
 ### TRAIN FUNCTION ARGS ###
-train_epochs: 1
+train_epochs: 15
 batch_size: 8

--- a/examples/image_classification/cifar10/main.py
+++ b/examples/image_classification/cifar10/main.py
@@ -3,24 +3,22 @@ import yaml, json
 from alectio_sdk.flask_wrapper import Pipeline
 from processes import train, test, infer, getdatasetstate
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--config", help="Path to config.yaml", required=True)
-args = parser.parse_args()
-
-with open(args.config, "r") as stream:
+with open("./config.yaml", "r") as stream:
     args = yaml.safe_load(stream)
 
 # put the train/test/infer processes into the constructor
-app = Pipeline(
-    name=args["exp_name"],
-    train_fn=train,
-    test_fn=test,
-    infer_fn=infer,
-    getstate_fn=getdatasetstate,
-    args=args,
+AlectioPipeline  = Pipeline(
+                            name=args["exp_name"],
+                            train_fn=train,
+                            test_fn=test,
+                            infer_fn=infer,
+                            getstate_fn=getdatasetstate,
+                            args=args,
 )
 
+app = AlectioPipeline.app
+
 if __name__ == "__main__":
-    payload = json.load(open(args["sample_payload"], "r"))
-    app._one_loop(args=args, payload=payload)
-    #app(debug=True)
+    # payload = json.load(open(args["sample_payload"], "r"))
+    # app._one_loop(args=args, payload=payload)
+    app.run()

--- a/examples/image_classification/cifar10/main.py
+++ b/examples/image_classification/cifar10/main.py
@@ -21,6 +21,6 @@ app = Pipeline(
 )
 
 if __name__ == "__main__":
-    # payload = json.load(open(args["sample_payload"], "r"))
-    # app._one_loop(args=args, payload=payload)
-    app(debug=True)
+    payload = json.load(open(args["sample_payload"], "r"))
+    app._one_loop(args=args, payload=payload)
+    #app(debug=True)

--- a/examples/image_classification/cifar10/processes.py
+++ b/examples/image_classification/cifar10/processes.py
@@ -120,23 +120,24 @@ def infer(args, unlabeled, ckpt_file):
 
     correct, total, k = 0, 0, 0
     outputs_fin = {}
-    with torch.no_grad():
-        for i, data in tqdm(enumerate(unlabeled_loader), desc="Inferring"):
-            images, labels = data
-            images, labels = images.to(device), labels.to(device)
-            outputs = net(images)
-            _, predicted = torch.max(outputs.data, 1)
-            total += labels.size(0)
-            correct += (predicted == labels).sum().item()
+    for i, data in tqdm(enumerate(unlabeled_loader), desc="Inferring"):
+        images, labels = data
+        images, labels = images.to(device), labels.to(device)
+        outputs = net(images).data
+        # print("*" * 10)
+        # print(outputs.shape)
 
-            for j in range(len(outputs)):
-                outputs_fin[k] = {}
-                outputs_fin[k]["prediction"] = predicted[j].item()
-                outputs_fin[k]["pre_softmax"] = outputs[j].cpu().numpy()
-                k += 1
+        _, predicted = torch.max(outputs, 1)
+        total += labels.size(0)
+        correct += (predicted == labels).sum().item()
+
+        for j in range(len(outputs)):
+            outputs_fin[k] = {}
+            outputs_fin[k]["prediction"] = predicted[j].item()
+            outputs_fin[k]["pre_softmax"] = outputs[j].cpu().numpy().tolist()
+            k += 1
 
     return {"outputs": outputs_fin}
-
 
 if __name__ == "__main__":
     labeled = list(range(1000))

--- a/examples/image_classification/cifar10/processes.py
+++ b/examples/image_classification/cifar10/processes.py
@@ -36,6 +36,7 @@ def train(args, labeled, resume_from, ckpt_file):
         trainset, batch_size=batch_size, shuffle=False, num_workers=2
     )
 
+    predictions, targets = [], []
     net = Net().to(device)
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.SGD(net.parameters(), lr=lr, momentum=momentum)
@@ -56,6 +57,9 @@ def train(args, labeled, resume_from, ckpt_file):
 
             outputs = net(images)
             loss = criterion(outputs, labels)
+            _, predicted = torch.max(outputs.data, 1)
+            predictions.extend(predicted.cpu().numpy().tolist())
+            targets.extend(labels.cpu().numpy().tolist())
 
             optimizer.zero_grad()
             loss.backward()
@@ -67,7 +71,7 @@ def train(args, labeled, resume_from, ckpt_file):
     ckpt = {"model": net.state_dict(), "optimizer": optimizer.state_dict()}
     torch.save(ckpt, os.path.join(args["EXPT_DIR"], ckpt_file))
 
-    return
+    return {"predictions": predictions, "labels": targets}
 
 
 def test(args, ckpt_file):

--- a/examples/image_classification/cifar10/processes.py
+++ b/examples/image_classification/cifar10/processes.py
@@ -124,8 +124,6 @@ def infer(args, unlabeled, ckpt_file):
         images, labels = data
         images, labels = images.to(device), labels.to(device)
         outputs = net(images).data
-        # print("*" * 10)
-        # print(outputs.shape)
 
         _, predicted = torch.max(outputs, 1)
         total += labels.size(0)

--- a/examples/image_classification/cifar10/sample_payload.json
+++ b/examples/image_classification/cifar10/sample_payload.json
@@ -4,5 +4,7 @@
     "cur_loop": 0,
     "user_id": "8a90a570972811eaad5238c986352c36",
     "type": "Classification",
+    "n_rec": 5000,
+    "n_loop": 10,
     "bucket_name": "alectio-demo"
 }

--- a/examples/object_detection/config.yaml
+++ b/examples/object_detection/config.yaml
@@ -1,5 +1,5 @@
 sample_payload: 'sample_payload.json'
-EXPT_DIR : "./COCOexperiment"             ####### Will contain all experiment related checkpoints and other logs 
+EXPT_DIR : "./COCOexperiment"             ####### Will contain all experiment related checkpoints and other logs
 DATA_DIR : "./data"
 IMAGEDATA_DIR : "./data/images/"
 TRAINIMAGEDATA_DIR : "./data/images/train"


### PR DESCRIPTION
### Related Jira story
--------------------------

RES - 334

### Did you modify the folder `alectio_sdk`? If so, describe your changes in detail
-------------------------------------------------------------------------------------

Yes, I have added 2 changes: 
- Included `num_queried_per_class` in `insights.pkl` if the `train_fn` returns `{"predictions": predictions, "labels": targets}`. Keep it like always if the `train_fn` returns None
- Added estimated compute time to estimate the amount of time remaining for the experiment

### If you have made any changes to an existing example, please go through the following list
--------------------------------------------------------------------------------------------------------
**Example name**:  Image classification

- [x] I have tried an end-to-end test (involving the front-end, backend, and AL engine) and it was successful
- [x] Loss, metrics, etc. look reasonable/consistent to me
- [x] If necessary, I updated related files such as `requirements.txt` and `README.md` 

### Describe your change in detail and any other comments
------------------------------------------------------------
This change was needed so that later, the platform team can display this information on the front end. We can build on this by calculating `test` and `infer` time in the future.

### Describe any bugs or inconsistencies you may have encountered along the way
---------------------------------------------------------------------------------
- Had trouble with regular_al / manual_al as I wasn't receiving a payload.
